### PR TITLE
Upload COGs to S3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,11 +43,11 @@ Asset type (`thumbs`, `scans`) carried through every stage:
 ```
 data/raw/thumbs/{year}/*.jpg              — downloaded thumbnails
 data/raw/georef/thumbs/{year}/*.tif       — georeferenced GeoTIFFs
-data/stac/bc-airphoto/thumbs/{year}/*.tif — COGs (synced to S3)
+data/stac/thumbs/{year}/*.tif             — COGs (synced to s3://stac-airphoto-bc/)
 
 data/raw/scans/{year}/*.tif               — downloaded full-res scans (future)
 data/raw/georef/scans/{year}/*.tif        — georeferenced full-res (future)
-data/stac/bc-airphoto/scans/{year}/*.tif  — COGs (synced to S3, future)
+data/stac/scans/{year}/*.tif              — COGs (synced to S3, future)
 ```
 
 One STAC collection (`bc-airphoto`), one item per physical photo (`airp_id`), multiple assets:

--- a/scripts/00_review_samples.R
+++ b/scripts/00_review_samples.R
@@ -1,0 +1,98 @@
+# 00_review_samples.R — sample and inspect thumbnails across years
+#
+# Downloads 1-2 random thumbnails per year (if not already on disk),
+# reports band count, datatype, dimensions, and pixel stats.
+# Reusable for any AOI — just swap the parquet cache and AOI.
+
+library(sf)
+library(dplyr)
+library(arrow)
+library(fly)
+library(terra)
+
+n_per_year <- 2
+seed <- 42
+
+# --- Load centroids from cache -------------------------------------------
+
+centroids_raw <- arrow::read_parquet("data/centroids_raw.parquet") |>
+  sf::st_as_sf(coords = c("longitude", "latitude"), crs = 4326) |>
+  sf::st_transform(3005)
+
+aoi <- fresh::frs_watershed_at_measure(
+  blue_line_key = 360873822,
+  downstream_route_measure = 166030.4
+) |> sf::st_transform(3005)
+
+centroids <- fly::fly_filter(centroids_raw, aoi, method = "footprint") |>
+  dplyr::mutate(year = as.integer(photo_year)) |>
+  dplyr::filter(!is.na(thumbnail_image_url))
+
+# --- Sample n per year ---------------------------------------------------
+
+set.seed(seed)
+samples <- centroids |>
+  dplyr::group_by(year) |>
+  dplyr::slice_sample(n = n_per_year) |>
+  dplyr::ungroup()
+
+message("Sampled ", nrow(samples), " photos across ", n_distinct(samples$year), " years")
+
+# --- Fetch samples -------------------------------------------------------
+
+dest_dir <- "data/raw/thumbs/samples"
+
+fetch_result <- fly::fly_fetch(
+  samples,
+  type = "thumbnail",
+  dest_dir = dest_dir,
+  workers = 6
+)
+
+# --- Inspect each thumbnail ----------------------------------------------
+
+inspect <- purrr::map_dfr(seq_len(nrow(fetch_result)), function(i) {
+  fr <- fetch_result[i, ]
+  if (!fr$success || !file.exists(fr$dest)) {
+    return(tibble::tibble(
+      airp_id = fr$airp_id, year = NA_integer_, file = fr$dest,
+      bands = NA, datatype = NA, width = NA, height = NA,
+      min_val = NA, max_val = NA, mean_val = NA, note = "fetch failed"
+    ))
+  }
+
+  r <- terra::rast(fr$dest)
+  g <- terra::global(r[[1]], c("min", "max", "mean"), na.rm = TRUE)
+  yr <- samples$year[samples$airp_id == fr$airp_id][1]
+
+  tibble::tibble(
+    airp_id = fr$airp_id,
+    year = yr,
+    file = basename(fr$dest),
+    bands = terra::nlyr(r),
+    datatype = terra::datatype(r),
+    width = terra::ncol(r),
+    height = terra::nrow(r),
+    min_val = round(g$min, 1),
+    max_val = round(g$max, 1),
+    mean_val = round(g$mean, 1),
+    note = dplyr::case_when(
+      terra::nlyr(r) == 1 ~ "grayscale",
+      terra::nlyr(r) == 3 ~ "RGB",
+      terra::nlyr(r) == 4 ~ "RGBA",
+      TRUE ~ paste0(terra::nlyr(r), " bands")
+    )
+  )
+})
+
+# --- Report ---------------------------------------------------------------
+
+message("\n--- Thumbnail inspection ---")
+inspect |>
+  dplyr::arrange(year) |>
+  print(n = 50)
+
+message("\n--- Summary by type ---")
+inspect |>
+  dplyr::count(note, bands, datatype, width, height) |>
+  print()

--- a/scripts/01_fetch.R
+++ b/scripts/01_fetch.R
@@ -70,7 +70,7 @@ message(
 # Path convention carries asset type at every stage:
 #   data/raw/thumbs/{year}/*.jpg          — downloaded thumbnails
 #   data/raw/georef/thumbs/{year}/*.tif   — georeferenced GeoTIFFs
-#   data/stac/bc-airphoto/thumbs/{year}/*.tif — COGs for S3
+#   data/stac/thumbs/{year}/*.tif — COGs (synced to s3://stac-airphoto-bc/)
 # Full-res scans follow the same pattern with "scans" instead of "thumbs".
 # fly_fetch(overwrite = FALSE) skips existing files on disk.
 

--- a/scripts/03_cog.R
+++ b/scripts/03_cog.R
@@ -5,7 +5,7 @@ library(terra)
 # --- Find georeferenced TIFFs -------------------------------------------
 
 georef_dir <- file.path("data", "raw", "georef", "thumbs")
-stac_dir <- file.path("data", "stac", "bc-airphoto", "thumbs")
+stac_dir <- file.path("data", "stac", "thumbs")
 
 georef_files <- list.files(georef_dir, pattern = "\\.tif$",
                            recursive = TRUE, full.names = TRUE)

--- a/scripts/04_s3_upload.R
+++ b/scripts/04_s3_upload.R
@@ -1,0 +1,26 @@
+# 04_s3_upload.R — sync COGs to S3
+
+bucket <- "stac-airphoto-bc"
+local_dir <- file.path("data", "stac")
+
+if (!dir.exists(local_dir)) {
+  stop("No COGs found at ", local_dir, " — run 03_cog.R first")
+}
+
+# --- Sync to S3 -----------------------------------------------------------
+# aws s3 sync uploads only new/changed files.
+# Local data/stac/ mirrors bucket root: thumbs/{year}/*.tif
+
+cmd <- sprintf(
+  "aws s3 sync %s s3://%s --exclude '.*' --size-only",
+  local_dir, bucket
+)
+
+message("Running: ", cmd)
+exit_code <- system(cmd)
+
+if (exit_code != 0) {
+  stop("S3 sync failed with exit code ", exit_code)
+}
+
+message("Sync complete")


### PR DESCRIPTION
Closes #4

## Summary
- `aws s3 sync data/stac/ s3://stac-airphoto-bc/` — local tree mirrors bucket root
- Fix directory layout: `data/stac/thumbs/{year}/` not `data/stac/bc-airphoto/thumbs/{year}/` (matches flat bucket convention from stac-dem-bc, stac-orthophoto-bc)
- Update path references in 01_fetch.R, 03_cog.R, CLAUDE.md
- Add 00_review_samples.R — reusable utility for inspecting thumbnail properties across years (found grayscale pre-1986, RGB post-1986)
- Bucket `stac-airphoto-bc` created via awshak (same config as other stac-* buckets)

## Test plan
- [x] 10 COGs uploaded to s3://stac-airphoto-bc/thumbs/1968/
- [x] Re-run syncs without re-uploading (--size-only)
- [x] Paths consistent across all scripts and CLAUDE.md

Relates to NewGraphEnvironment/sred-2025-2026#22

🤖 Generated with [Claude Code](https://claude.com/claude-code)
